### PR TITLE
Cleanup package cache after each installation

### DIFF
--- a/dockerfiles/archlinux
+++ b/dockerfiles/archlinux
@@ -26,12 +26,15 @@ RUN pacman --noconfirm -S git \
     sudo -u aur curl -o PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=pacaur' && \
     sudo -u aur makepkg PKGBUILD --skippgpcheck --install --needed --noconfirm && \
     cd / && \
-    rm -rf /build
+    rm -rf /build && \
+    pacman --noconfirm -Scc
 
 ENV EDITOR vim
 
 # install GPU related stuff
 RUN pacman --noconfirm -S nvidia \
                           nvidia-utils \
-                          cuda
+                          cuda \
+    && pacman --noconfirm -Scc
 RUN sudo -u aur pacaur --noconfirm --noedit -S cudnn6
+    && sudo -u aur pacaur --noconfirm -Scc

--- a/dockerfiles/cxflow
+++ b/dockerfiles/cxflow
@@ -4,7 +4,8 @@ MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 # install additional packages
 RUN pacman --noconfirm -S python-yaml \
                           python-ruamel-yaml \
-                          hdf5
+                          hdf5 \
+    && pacman --noconfirm -Scc
 
 # install Fuel                                            
 RUN pip install --no-cache-dir git+https://github.com/mila-udem/fuel.git 

--- a/dockerfiles/cxflow-cntk
+++ b/dockerfiles/cxflow-cntk
@@ -1,14 +1,14 @@
 FROM cognexa/cxflow
 MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 
-RUN pacman -Syyu && \
-    pacman --noconfirm -S openmpi && \
+RUN pacman --noconfirm -S openmpi && \
     ln -s /usr/lib/openmpi/libmpi.so  /usr/lib/openmpi/libmpi.so.12 && \
-    ln -s /usr/lib/openmpi/libmpi_cxx.so  /usr/lib/openmpi/libmpi_cxx.so.1
+    ln -s /usr/lib/openmpi/libmpi_cxx.so  /usr/lib/openmpi/libmpi_cxx.so.1 && \
+    pacman --noconfirm -Scc
 
 ENV LD_LIBRARY_PATH /usr/lib/openmpi:$LD_LIBRARY_PATH
 
-RUN pip install https://cntk.ai/PythonWheel/GPU/cntk-2.0-cp36-cp36m-linux_x86_64.whl
+RUN pip install --no-cache-dir https://cntk.ai/PythonWheel/GPU/cntk-2.0-cp36-cp36m-linux_x86_64.whl
 
 # install cxflow-cntk
-RUN pip install git+https://github.com/Cognexa/cxflow-cntk.git
+RUN pip install --no-cache-dir git+https://github.com/Cognexa/cxflow-cntk.git

--- a/dockerfiles/cxflow-tensorflow
+++ b/dockerfiles/cxflow-tensorflow
@@ -1,7 +1,8 @@
 FROM cognexa/cxflow
 MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 
-RUN pacman --noconfirm -S python-tensorflow-opt-cuda
+RUN pacman --noconfirm -S python-tensorflow-opt-cuda \
+    && pacman --noconfirm -Scc
 
 # install cxflow-tensorflow
 RUN pip install --no-cache-dir git+https://github.com/Cognexa/cxflow-tensorflow.git


### PR DESCRIPTION
Our images are very large (~8.5 GB for `cxflow-tensorflow`). Clearing the package cache immediately after each installation may reduce the size significantly.