### PR TITLE
Install cudnn from main repo

### DIFF
--- a/dockerfiles/archlinux
+++ b/dockerfiles/archlinux
@@ -35,6 +35,5 @@ ENV EDITOR vim
 RUN pacman --noconfirm -S nvidia \
                           nvidia-utils \
                           cuda \
+                          cudnn \
     && pacman --noconfirm -Scc
-RUN sudo -u aur pacaur --noconfirm --noedit -S cudnn6 \
-    && sudo -u aur pacaur --noconfirm -Scc


### PR DESCRIPTION
Because I forgot one backslash. :-/

edit: It is not necessary to install `cudnn` from AUR, so I removed those lines entirely.