### PR TITLE
Fix fuel

### DIFF
--- a/dockerfiles/cxflow
+++ b/dockerfiles/cxflow
@@ -7,9 +7,6 @@ RUN pacman --noconfirm -S python-yaml \
                           hdf5 \
     && pacman --noconfirm -Scc
 
-# install Fuel                                            
-RUN pip install --no-cache-dir git+https://github.com/mila-udem/fuel.git 
-
 # install cxflow                                          
 RUN pip install --no-cache-dir git+https://github.com/Cognexa/cxflow.git && \
     pip install --no-cache-dir git+https://github.com/Cognexa/cxflow-scikit.git


### PR DESCRIPTION
@blazekadam @petrbel Please can we stop installing `fuel` (or at least with sudo `pip`) in `cxflow` Dockerfile? It is a monster with fixed package versions in [requirements](https://github.com/mila-udem/fuel/blob/master/requirements.txt), which removes all your precious optimized packages, installs them from PyPI and renders it practially impossible to install anything with package manager afterwards (because the files already exist). And we don't use it anywhere anyway.