### PR TITLE
Revision

### DIFF
--- a/dockerfiles/archlinux
+++ b/dockerfiles/archlinux
@@ -1,39 +1,42 @@
 FROM pritunl/archlinux
 MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 
-# install common packages, setup up user `aur` and install `pacaur` and `yaourt`
-RUN pacman --noconfirm -S git \
-                          expac \
-                          yajl \
-                          base-devel \
-                          opencv \
-                          python \
-                          vim \
-                          python-numpy \
-                          python-pandas \
-                          python-scipy \
-                          python-pip && \
-    useradd -m -s /bin/bash aur && \
-    passwd -d aur && \
-    echo 'aur ALL=(ALL) ALL' > /etc/sudoers.d/aur && \
-    echo 'Defaults env_keep += "EDITOR"' >> /etc/sudoers.d/aur && \
-    mkdir /build && \
-    chown -R aur:aur /build && \
-    cd /build && \
-    export PATH="/usr/bin/core_perl:$PATH" && \
-    sudo -u aur curl -o PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=cower' && \
-    sudo -u aur makepkg PKGBUILD --skippgpcheck --install --needed --noconfirm && \
-    sudo -u aur curl -o PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=pacaur' && \
-    sudo -u aur makepkg PKGBUILD --skippgpcheck --install --needed --noconfirm && \
-    cd / && \
-    rm -rf /build && \
-    pacman --noconfirm -Scc
+# install common packages, setup up user `aur` and install `pacaur`
+RUN pacman --noconfirm --needed -S \
+      git \
+      expac \
+      yajl \
+      base-devel \
+      opencv \
+      python \
+      vim \
+      python-numpy \
+      python-pandas \
+      python-scipy \
+      python-pip
+
+RUN useradd -m -s /bin/bash aur \
+    && passwd -d aur \
+    && echo 'aur ALL=(ALL) ALL' > /etc/sudoers.d/aur \
+    && echo 'Defaults env_keep += "EDITOR"' >> /etc/sudoers.d/aur \
+    && mkdir /build \
+    && chown -R aur:aur /build \
+    && cd /build \
+    && export PATH="/usr/bin/core_perl:$PATH" \
+    && sudo -u aur curl -o PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=cower' \
+    && sudo -u aur makepkg PKGBUILD --skippgpcheck --install --needed --noconfirm \
+    && sudo -u aur curl -o PKGBUILD 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=pacaur' \
+    && sudo -u aur makepkg PKGBUILD --skippgpcheck --install --needed --noconfirm \
+    && cd / \
+    && rm -rf /build \
+    && pacman --noconfirm -Scc
 
 ENV EDITOR vim
 
 # install GPU related stuff
-RUN pacman --noconfirm -S nvidia \
-                          nvidia-utils \
-                          cuda \
-                          cudnn \
+RUN pacman --noconfirm --needed -S \
+      nvidia \
+      nvidia-utils \
+      cuda \
+      cudnn \
     && pacman --noconfirm -Scc

--- a/dockerfiles/cxflow
+++ b/dockerfiles/cxflow
@@ -2,11 +2,22 @@ FROM cognexa/archlinux
 MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 
 # install additional packages
-RUN pacman --noconfirm -S python-yaml \
-                          python-ruamel-yaml \
-                          hdf5 \
+RUN pacman --noconfirm --needed -S \
+      python-babel \
+      python-click \
+      python-matplotlib \
+      python-numpy \
+      python-pyaml \
+      python-requests \
+      python-ruamel-yaml \
+      python-testfixtures \
     && pacman --noconfirm -Scc
 
+RUN sudo -u aur pacaur --noconfirm --noedit --needed -S \
+      python-typing \
+      python-tabulate \
+    && sudo -u aur pacaur --noconfirm -Scc
+
 # install cxflow                                          
-RUN pip install --no-cache-dir git+https://github.com/Cognexa/cxflow.git && \
-    pip install --no-cache-dir git+https://github.com/Cognexa/cxflow-scikit.git
+RUN pip install --no-cache-dir git+https://github.com/Cognexa/cxflow.git \
+    && pip install --no-cache-dir git+https://github.com/Cognexa/cxflow-scikit.git

--- a/dockerfiles/cxflow
+++ b/dockerfiles/cxflow
@@ -7,9 +7,6 @@ RUN pacman --noconfirm -S python-yaml \
                           hdf5 \
     && pacman --noconfirm -Scc
 
-# install Fuel                                            
-RUN pip install --no-cache-dir git+https://github.com/mila-udem/fuel.git 
-
 # install cxflow                                          
 RUN pip install --no-cache-dir git+https://github.com/Cognexa/cxflow.git && \
     pip install --no-cache-dir git+https://github.com/Cognexa/cxflow-scikit.git

--- a/dockerfiles/cxflow-cntk
+++ b/dockerfiles/cxflow-cntk
@@ -1,10 +1,10 @@
 FROM cognexa/cxflow
 MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 
-RUN pacman --noconfirm -S openmpi && \
-    ln -s /usr/lib/openmpi/libmpi.so  /usr/lib/openmpi/libmpi.so.12 && \
-    ln -s /usr/lib/openmpi/libmpi_cxx.so  /usr/lib/openmpi/libmpi_cxx.so.1 && \
-    pacman --noconfirm -Scc
+RUN pacman --noconfirm --needed -S openmpi \
+    && ln -s /usr/lib/openmpi/libmpi.so  /usr/lib/openmpi/libmpi.so.12 \
+    && ln -s /usr/lib/openmpi/libmpi_cxx.so  /usr/lib/openmpi/libmpi_cxx.so.1 \
+    && pacman --noconfirm -Scc
 
 ENV LD_LIBRARY_PATH /usr/lib/openmpi:$LD_LIBRARY_PATH
 

--- a/dockerfiles/cxflow-tensorflow
+++ b/dockerfiles/cxflow-tensorflow
@@ -1,7 +1,9 @@
 FROM cognexa/cxflow
 MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 
-RUN pacman --noconfirm -S python-tensorflow-opt-cuda \
+RUN pacman --noconfirm --needed -S \
+      python-tensorflow-opt-cuda \
+      tensorboard \
     && pacman --noconfirm -Scc
 
 # install cxflow-tensorflow


### PR DESCRIPTION
- install from repository if possible
  - easier to manage (can be uninstalled / changed in inherited image, pip harder)
  - easier to go back in time and fix system versions
  - faster to build image
- skip already installed packages
  - may help image size
  - faster to build
- unify indentation and code style
- get rid of fuel
  - uses fixed package versions, so everything gets uninstalled and installed from pip
  - has a lot of dependencies
  - it is not a dependency of `cxflow`

(I have manually built and tested the `cxflow-tensorflow` image)