### PR TITLE
Fix package cache cleanup

### DIFF
--- a/dockerfiles/archlinux
+++ b/dockerfiles/archlinux
@@ -13,7 +13,8 @@ RUN pacman --noconfirm --needed -S \
       python-numpy \
       python-pandas \
       python-scipy \
-      python-pip
+      python-pip \
+    && paccache -rfk0
 
 RUN useradd -m -s /bin/bash aur \
     && passwd -d aur \
@@ -29,7 +30,7 @@ RUN useradd -m -s /bin/bash aur \
     && sudo -u aur makepkg PKGBUILD --skippgpcheck --install --needed --noconfirm \
     && cd / \
     && rm -rf /build \
-    && pacman --noconfirm -Scc
+    && paccache -rfk0
 
 ENV EDITOR vim
 
@@ -39,4 +40,4 @@ RUN pacman --noconfirm --needed -S \
       nvidia-utils \
       cuda \
       cudnn \
-    && pacman --noconfirm -Scc
+    && paccache -rfk0

--- a/dockerfiles/cxflow
+++ b/dockerfiles/cxflow
@@ -11,12 +11,13 @@ RUN pacman --noconfirm --needed -S \
       python-requests \
       python-ruamel-yaml \
       python-testfixtures \
-    && pacman --noconfirm -Scc
+    && paccache -rfk0
 
 RUN sudo -u aur pacaur --noconfirm --noedit --needed -S \
       python-typing \
       python-tabulate \
-    && sudo -u aur pacaur --noconfirm -Scc
+    && rm -rf ~/.cache \
+    && paccache -rfk0
 
 # install cxflow                                          
 RUN pip install --no-cache-dir git+https://github.com/Cognexa/cxflow.git \

--- a/dockerfiles/cxflow-cntk
+++ b/dockerfiles/cxflow-cntk
@@ -4,7 +4,7 @@ MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 RUN pacman --noconfirm --needed -S openmpi \
     && ln -s /usr/lib/openmpi/libmpi.so  /usr/lib/openmpi/libmpi.so.12 \
     && ln -s /usr/lib/openmpi/libmpi_cxx.so  /usr/lib/openmpi/libmpi_cxx.so.1 \
-    && pacman --noconfirm -Scc
+    && paccache -rfk0
 
 ENV LD_LIBRARY_PATH /usr/lib/openmpi:$LD_LIBRARY_PATH
 

--- a/dockerfiles/cxflow-tensorflow
+++ b/dockerfiles/cxflow-tensorflow
@@ -4,7 +4,7 @@ MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 RUN pacman --noconfirm --needed -S \
       python-tensorflow-opt-cuda \
       tensorboard \
-    && pacman --noconfirm -Scc
+    && paccache -rfk0
 
 # install cxflow-tensorflow
 RUN pip install --no-cache-dir git+https://github.com/Cognexa/cxflow-tensorflow.git


### PR DESCRIPTION
You think that `pacman --noconfirm -Scc` cleans up the package cache? Think again (and you will see that NO is the default option)...