### PR TITLE
Remove indirectly installed nvidia utils

### DIFF
--- a/dockerfiles/cxflow-tensorflow
+++ b/dockerfiles/cxflow-tensorflow
@@ -5,6 +5,8 @@ MAINTAINER Cognexa Solutions s.r.o. <docker@cognexa.com>
 ARG tag
 RUN if [ "${tag}" = "cuda" ]; then \
         pacman --noconfirm --needed -S python-tensorflow-opt-cuda; \
+        pacman --noconfirm -Rdd nvidia-utils; \
+        pacman --noconfirm -Rns $(pacman -Qtdq); \
     else \
         pacman --noconfirm --needed -S python-tensorflow-opt; \
     fi \


### PR DESCRIPTION
@blazekadam This fixes the problem with indirectly installed nvidia utils. It is tested with a different GPU driver version on host and `nvidia-smi` and tensorflow can recognize the GPU's.