### PR TITLE
Remove python-typing from dependencies

### DIFF
--- a/dockerfiles/cxflow
+++ b/dockerfiles/cxflow
@@ -15,7 +15,6 @@ RUN pacman --noconfirm --needed -S \
     && paccache -rfk0
 
 RUN sudo -u aur trizen --noconfirm --needed -S \
-      python-typing \
       python-tabulate \
     && paccache -rfk0 \
     && trizen -Scc --noconfirm


### PR DESCRIPTION
This may (or may not) fix the issue with our automatic builds on docker hub.
(e.g., https://hub.docker.com/r/cognexa/cxflow/builds/bsnu8er6rkvh9v7rpzwdxuu/ )

By the way @adkoadko @ludakas you should create a DockerHub account and add yourself to the collaborators of the Cognexa group in order to receive an email when an automatic build fails.